### PR TITLE
Add hashed RSP schema with meta index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-# rhif
+# RHIF
+
+Upgraded RHIF Clip-On with recursive packet hashing and metadata indexing.
+Run tests with `pytest` inside the `rhif-clipon` directory.

--- a/rhif-clipon/hub/db.py
+++ b/rhif-clipon/hub/db.py
@@ -1,7 +1,9 @@
 import json
 import sqlite3
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
+
+from rhif_utils import canonical_json, rsp_hash, flatten_meta
 
 from flask import current_app
 
@@ -21,27 +23,53 @@ def execute(sql: str, *params) -> List[sqlite3.Row]:
 
 
 def insert_rsp(row: Dict[str, Any]) -> int:
-    fields = [
+    """Insert an RSP row and its meta index."""
+    base_fields = [
         'conv_id', 'turn', 'role', 'date', 'text',
-        'summary', 'keywords', 'tags', 'tokens'
+        'summary', 'keywords', 'tags', 'tokens',
+        'meta', 'children', 'domain', 'topic',
+        'conversation_type', 'emotion', 'novelty', 'hash'
     ]
-    row = {k: row.get(k) for k in fields}
-    placeholders = ','.join('?' for _ in fields)
-    sql = f"INSERT INTO rsp ({','.join(fields)}) VALUES ({placeholders})"
+    row = {k: row.get(k) for k in base_fields}
+
+    # build meta pairs from hot axes if meta not provided
+    meta_pairs: List[Dict[str, Any]] = []
+    for axis in ['domain', 'topic', 'conversation_type', 'emotion', 'novelty']:
+        if row.get(axis):
+            meta_pairs.append({'dimension': axis, 'value': row[axis]})
+    if row.get('meta'):
+        meta_pairs.extend(json.loads(row['meta']))
+    row['meta'] = json.dumps(meta_pairs)
+
+    row['hash'] = row.get('hash') or rsp_hash(row.get('text', ''), meta_pairs, json.loads(row.get('children', '[]') or '[]'))
+
+    placeholders = ','.join('?' for _ in base_fields)
+    sql = f"INSERT INTO rsp ({','.join(base_fields)}) VALUES ({placeholders})"
     with get_db() as conn:
-        cur = conn.execute(sql, [row[k] for k in fields])
+        cur = conn.execute(sql, [row[k] for k in base_fields])
         rowid = cur.lastrowid
         conn.execute(
             "INSERT INTO rsp_fts(rowid, text, summary, keywords) VALUES (?,?,?,?)",
             (rowid, row['text'], row['summary'], row['keywords'])
         )
+        # index meta
+        for idx in flatten_meta(row['hash'], meta_pairs, json.loads(row.get('children', '[]') or '[]')):
+            conn.execute(
+                "INSERT INTO rsp_index(hash, dimension, value, dimension_hash, context_path) VALUES (?,?,?,?,?)",
+                (idx['hash'], idx['dimension'], idx['value'], idx['dimension_hash'], idx['context_path'])
+            )
         conn.commit()
     return rowid
 
 
-def search_rsps(query: str, tags: Optional[List[str]] = None, limit: int = 10) -> List[Dict[str, Any]]:
+def search_rsps(query: str,
+                tags: Optional[List[str]] = None,
+                limit: int = 10,
+                domain: Optional[str] = None,
+                topic: Optional[str] = None) -> List[Dict[str, Any]]:
+    """Search RSPs using FTS with optional tag and axis filters."""
     sql = (
-        "SELECT id, conv_id, turn, role, date, text, summary, keywords, tags, tokens "
+        "SELECT id, conv_id, turn, role, date, text, summary, keywords, tags, tokens, domain, topic "
         "FROM rsp_fts JOIN rsp ON rsp_fts.rowid = rsp.id "
         "WHERE rsp_fts MATCH ?"
     )
@@ -50,6 +78,12 @@ def search_rsps(query: str, tags: Optional[List[str]] = None, limit: int = 10) -
         tag_clause = ' AND '.join(["json_extract(tags, '$') LIKE ?" for _ in tags])
         sql += f" AND {tag_clause}"
         params += [f'%{t}%' for t in tags]
+    if domain:
+        sql += " AND domain = ?"
+        params.append(domain)
+    if topic:
+        sql += " AND topic = ?"
+        params.append(topic)
     sql += " ORDER BY id DESC LIMIT ?"
     params.append(limit)
     rows = execute(sql, *params)

--- a/rhif-clipon/hub/ollama_helpers.py
+++ b/rhif-clipon/hub/ollama_helpers.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
 import json
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 
 import ollama
 
 
-def summarise_and_keywords(text: str, model: str, kw_count: int, summary_tokens: int) -> Tuple[str, List[str]]:
+def summarise_and_keywords(text: str, model: str, kw_count: int, summary_tokens: int) -> Tuple[str, List[str], Dict[str, str]]:
     prompt = (
         "You are a summarization assistant.\n"
         f"TASK A \u2013 Summarise the message below in \u2264{summary_tokens} words.\n"
         f"TASK B \u2013 Output exactly {kw_count} lowercase single-word keywords, comma-separated.\n"
         'Respond *only* in JSON:\n'
-        '{ "summary": "...", "keywords": ["kw1","kw2",...] }\n'
+        '{ "summary": "...", "keywords": ["kw1","kw2",...], "domain": "", "topic": "", "conversation_type": "", "emotion": "", "novelty": 1 }\n'
         'MESSAGE:\n"""' + text + '"""'
     )
 
@@ -22,4 +22,11 @@ def summarise_and_keywords(text: str, model: str, kw_count: int, summary_tokens:
     keywords = data.get('keywords', [])
     if isinstance(keywords, str):
         keywords = [k.strip() for k in keywords.split(',') if k.strip()]
-    return summary, keywords
+    meta = {
+        'domain': data.get('domain', ''),
+        'topic': data.get('topic', ''),
+        'conversation_type': data.get('conversation_type', ''),
+        'emotion': data.get('emotion', ''),
+        'novelty': data.get('novelty', 0)
+    }
+    return summary, keywords, meta

--- a/rhif-clipon/hub/rhif_utils.py
+++ b/rhif-clipon/hub/rhif_utils.py
@@ -1,0 +1,38 @@
+import hashlib
+import json
+from typing import Iterable, Dict, Any, Generator
+
+
+def canonical_json(data: Any) -> str:
+    """Return canonical JSON with sorted keys and no whitespace."""
+    return json.dumps(data, sort_keys=True, separators=(",", ":"))
+
+
+def rsp_hash(text: str, meta: Iterable[Dict[str, Any]] | None = None, children: Iterable[str] | None = None) -> str:
+    """Compute SHA-256 hash for an RSP packet."""
+    obj = {
+        "text": text,
+        "meta": list(meta or []),
+        "children": list(children or []),
+    }
+    return hashlib.sha256(canonical_json(obj).encode()).hexdigest()
+
+
+def dimension_hash(dimension: str, value: str) -> str:
+    """Return SHA-256 hash for a dimension/value pair."""
+    return hashlib.sha256(f"{dimension}:{value}".encode()).hexdigest()
+
+
+def flatten_meta(rsp_hash_value: str, meta: Iterable[Dict[str, Any]], context_path: Iterable[str] | None = None) -> Generator[Dict[str, Any], None, None]:
+    """Yield flattened rows for the meta index."""
+    path = list(context_path or [])
+    for pair in meta:
+        dim = pair.get("dimension")
+        val = pair.get("value")
+        yield {
+            "hash": rsp_hash_value,
+            "dimension": dim,
+            "value": val,
+            "dimension_hash": dimension_hash(dim, val),
+            "context_path": json.dumps(path),
+        }

--- a/rhif-clipon/hub/templates/search.html
+++ b/rhif-clipon/hub/templates/search.html
@@ -10,7 +10,7 @@
 <h1 class="title">Search Results</h1>
 {% for row in rows %}
 <pre class="rsp" data-id="{{ row.id }}" data-tags="{{ row.tags }}">
-{{ row.id }} | {{ row.date }} | {{ row.role }} | {{ row.text }}
+{{ row.id }} | {{ row.domain }} | {{ row.topic }} | {{ row.date }} | {{ row.role }} | {{ row.text }}
 </pre>
 {% endfor %}
 </div>

--- a/rhif-clipon/tests/test_db.py
+++ b/rhif-clipon/tests/test_db.py
@@ -12,6 +12,7 @@ app.config['DB_PATH'] = ':memory:'
 with app.app_context():
     execute("""CREATE TABLE rsp (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
+        hash TEXT,
         conv_id TEXT,
         turn INTEGER,
         role TEXT,
@@ -20,13 +21,21 @@ with app.app_context():
         summary TEXT,
         keywords TEXT,
         tags TEXT,
-        tokens INTEGER
+        tokens INTEGER,
+        meta TEXT,
+        children TEXT,
+        domain TEXT,
+        topic TEXT,
+        conversation_type TEXT,
+        emotion TEXT,
+        novelty INTEGER
     )""")
     execute("CREATE VIRTUAL TABLE rsp_fts USING fts5(text, summary, keywords, content='rsp', content_rowid='id')")
+    execute("CREATE TABLE rsp_index(hash TEXT, dimension TEXT, value TEXT, dimension_hash TEXT, context_path TEXT)")
 
 def test_insert_and_search():
     with app.app_context():
-        rowid = insert_rsp({'conv_id':'1','turn':1,'role':'user','date':'2024-01-01','text':'hello','summary':'hi','keywords':'["hi"]','tags':'[]','tokens':1})
+        rowid = insert_rsp({'conv_id':'1','turn':1,'role':'user','date':'2024-01-01','text':'hello','summary':'hi','keywords':'["hi"]','tags':'[]','tokens':1,'domain':'test','topic':'unit'})
         res = search_rsps('hello', [], 10)
         assert len(res) == 1
         assert res[0]['id'] == rowid


### PR DESCRIPTION
## Summary
- add README overview
- implement RSP hashing helpers
- expand database schema with meta columns and flatten index
- update hub to store metadata from LLM summariser
- extend search template to show domain/topic
- adjust tests for new schema

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68550f0530888322a3d3d6c20eb930fc