### PR TITLE
Fix logging encoding for ollama errors

### DIFF
--- a/rhif-clipon/hub/ollama_helpers.py
+++ b/rhif-clipon/hub/ollama_helpers.py
@@ -14,8 +14,12 @@ MAX_PROMPT_CHARS = int(os.getenv("OLLAMA_MAX_PROMPT", "32000"))
 # error logger for failed ollama JSON responses
 logger = logging.getLogger("ollama")
 if not logger.handlers:
-    handler = logging.FileHandler("ollama_errors.log")
-    handler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s: %(message)s"))
+    handler = logging.FileHandler(
+        "ollama_errors.log", encoding="utf-8", errors="replace"
+    )
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)s: %(message)s")
+    )
     logger.addHandler(handler)
     logger.setLevel(logging.ERROR)
 


### PR DESCRIPTION
## Summary
- ensure ollama error logger writes using UTF-8

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask', ModuleNotFoundError: No module named 'ollama')*

------
https://chatgpt.com/codex/tasks/task_e_6855d7c764ec832296df42bb487b5f7f