### PR TITLE
Improve Ollama JSON parsing

### DIFF
--- a/rhif-clipon/hub/requirements.txt
+++ b/rhif-clipon/hub/requirements.txt
@@ -4,3 +4,4 @@ ollama~=0.1
 ijson~=3.2
 python-dotenv~=1.0
 tqdm~=4.0
+regex~=2023.0


### PR DESCRIPTION
## Summary
- make the Ollama parser robust to malformed JSON
- tighten the generate prompt with a system role and safer options
- install the `regex` module for recursive JSON matching

## Testing
- `pip install -r rhif-clipon/hub/requirements.txt -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855deb99b2c83228e54fce67089a935