### PR TITLE
Fix JSON responses from Ollama

### DIFF
--- a/rhif-clipon/hub/ollama_helpers.py
+++ b/rhif-clipon/hub/ollama_helpers.py
@@ -95,10 +95,11 @@ def _summarise_once(
     response = ollama.generate(
         model=model,
         prompt=user_prompt,
-        system=system_prompt,  
+        system=system_prompt,
         # ➊ keep temperature 0 for deterministic output
-        # ➋ **remove** num_predict so the model can actually emit JSON
-        options={"temperature": 0, "stop": ["}```", "```"]},
+        # ➋ use Ollama's JSON mode to avoid extra text
+        format="json",
+        options={"temperature": 0},
         stream=False
     )
 


### PR DESCRIPTION
## Summary
- tweak ollama helper to use `format="json"`
- remove bad stop strings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855e511d48483229f3741da89972fca