### PR TITLE
Fix dynamic import in extension

### DIFF
--- a/rhif-clipon/extension/manifest.json
+++ b/rhif-clipon/extension/manifest.json
@@ -15,7 +15,7 @@
   ],
   "web_accessible_resources": [
     {
-      "resources": ["panel.html", "panel.css", "panel.js"],
+      "resources": ["panel.html", "panel.css", "panel.js", "utils.js"],
       "matches": ["<all_urls>"]
     }
   ]


### PR DESCRIPTION
## Summary
- expose `utils.js` as a web accessible resource so dynamic imports work

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68562d37ef8083229022cfca8a8105e1