### PR TITLE
Fix Rhif toggle button visibility and drag

### DIFF
--- a/rhif-clipon/extension/content.js
+++ b/rhif-clipon/extension/content.js
@@ -26,13 +26,14 @@ window.rhifContent = { getLatestChatTurns, insertAtCursor };
   link.href = chrome.runtime.getURL('panel.css');
   document.head.appendChild(link);
 
-  const { initPanel } = await import(chrome.runtime.getURL('panel.js'));
+  const { initPanel, makeDraggable } = await import(chrome.runtime.getURL('panel.js'));
   initPanel();
 
   const btn = document.createElement('div');
   btn.id = 'rhif-toggle-btn';
   btn.textContent = 'R';
   document.body.appendChild(btn);
+  makeDraggable(btn);
   btn.addEventListener('click', () => {
     panel.style.display = panel.style.display === 'none' || !panel.style.display ? 'block' : 'none';
   });

--- a/rhif-clipon/extension/panel.css
+++ b/rhif-clipon/extension/panel.css
@@ -1,8 +1,8 @@
-#rhif-toggle-btn { 
+#rhif-toggle-btn {
   position: fixed;
-  top: 80px;
-  left: 10px;
-  right: auto;
+  top: 10px;
+  right: 10px;
+  left: auto;
   width: 32px;
   height: 32px;
   background: #4caf50;

--- a/rhif-clipon/extension/panel.js
+++ b/rhif-clipon/extension/panel.js
@@ -42,7 +42,7 @@ export function initPanel() {
     if (e.key === 'Enter') runSearch();
   });
 }
-function makeDraggable(el) {
+export function makeDraggable(el) {
   let offsetX = 0, offsetY = 0, isDragging = false;
 
   el.addEventListener('mousedown', (e) => {


### PR DESCRIPTION
## Summary
- ensure Rhif button is visible in the top right
- export `makeDraggable` helper
- make Rhif toggle button draggable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685648e79d70832287bcfcb913b77c71