### PR TITLE
Update RHIF UI and add conversation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ KEYWORD_COUNT=8
 | `/summarise`  | POST  | Return summary, keywords and meta for provided text.            |
 | `/ingest`     | POST  | Store a conversation turn and its metadata.                     |
 | `/search`     | GET   | Full‑text search with optional tag/domain/topic filters.        |
+| `/conversation` | GET   | Retrieve all turns for a conversation by ID. |
 | `/savecode`   | POST  | Persist code blocks from markdown into the workspace directory. |
 | `/health`     | GET   | Liveness probe used by tests and the extension.                 |
 

--- a/rhif-clipon/extension/panel.css
+++ b/rhif-clipon/extension/panel.css
@@ -27,8 +27,7 @@
   position: fixed;
   top: 100px;
   left: 100px;
-  width: 320px;
-  max-height: 400px;
+  width: 480px;
   min-width: 200px;
   min-height: 150px;
   background: #fff;
@@ -36,7 +35,7 @@
   border: 1px solid #ccc;
   border-radius: 8px;
   box-shadow: inset 0 0 4px rgba(0,0,0,0.2), 0 2px 10px rgba(0,0,0,0.3);
-  padding: 10px;
+  padding: 12px;
   overflow: hidden;
   z-index: 10000;
   display: none;
@@ -59,7 +58,6 @@
   display: flex;
   gap: 4px;
   margin-bottom: 8px;
-  cursor: move;
 }
 #rhif-panel-header * {
   cursor: initial;
@@ -68,6 +66,10 @@
 #rhif-search {
   flex: 1;
   min-width: 0;
+}
+#rhif-move-handle {
+  width: 24px;
+  cursor: move;
 }
 #rhif-filter-toggle {
   width: 28px;
@@ -84,6 +86,11 @@
   opacity: 0;
   pointer-events: none;
   transition: max-height 0.3s ease, opacity 0.3s ease;
+}
+#rhif-main {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
 }
 #rhif-filter-panel.rhif-open {
   max-height: 500px;
@@ -106,7 +113,8 @@
   padding: 0;
   margin: 0;
   overflow-y: auto;
-  max-height: 150px;
+  width: 200px;
+  max-width: 50%;
 }
 
 .rhif-row {
@@ -129,10 +137,10 @@
 }
 
 #rhif-separator {
-  height: 4px;
+  width: 4px;
   background: #ccc;
-  cursor: ns-resize;
-  margin: 4px 0;
+  cursor: ew-resize;
+  margin: 0 4px;
 }
 
 #rhif-preview {
@@ -152,6 +160,12 @@
   margin-top: 4px;
   display: flex;
   gap: 4px;
+}
+#rhif-preview-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 #rhif-copy {
   transition: transform 0.1s;

--- a/rhif-clipon/extension/panel.html
+++ b/rhif-clipon/extension/panel.html
@@ -3,6 +3,7 @@
     <input type="text" id="rhif-search" placeholder="Search..." />
     <button id="rhif-theme-toggle">🌙</button>
     <button id="rhif-filter-toggle" title="Filters">⚙️</button>
+    <button id="rhif-move-handle" title="Move">✥</button>
   </div>
   <div id="rhif-filter-panel">
     <label>Date Range <input type="date" id="rhif-date-start"> -
@@ -13,12 +14,16 @@
     <label>Emotion <input type="text" id="rhif-emotion"></label>
     <label><input type="checkbox" id="rhif-slow-search"> Slow Search (Full Text)</label>
   </div>
-  <ul id="rhif-results"></ul>
-  <div id="rhif-separator"></div>
-  <div id="rhif-preview" class="rhif-hidden"></div>
-  <div id="rhif-preview-controls" class="rhif-hidden">
-    <button id="rhif-prev">⬅️ Previous</button>
-    <button id="rhif-next">Next ➡️</button>
-    <button id="rhif-copy" title="Recognize!">📋</button>
+  <div id="rhif-main">
+    <ul id="rhif-results"></ul>
+    <div id="rhif-separator"></div>
+    <div id="rhif-preview-area">
+      <div id="rhif-preview" class="rhif-hidden"></div>
+      <div id="rhif-preview-controls" class="rhif-hidden">
+        <button id="rhif-prev">⬅️ Previous</button>
+        <button id="rhif-next">Next ➡️</button>
+        <button id="rhif-copy" title="Recognize!">📋</button>
+      </div>
+    </div>
   </div>
 </div>

--- a/rhif-clipon/hub/db.py
+++ b/rhif-clipon/hub/db.py
@@ -256,3 +256,12 @@ def search_rsps(query: str,
     params.append(limit)
     rows = execute(sql, *params)
     return [dict(r) for r in rows]
+
+
+def fetch_conversation(conv_id: str) -> List[Dict[str, Any]]:
+    """Return all packets for a conversation ordered by turn."""
+    rows = execute(
+        "SELECT * FROM rsp WHERE conv_id = ? ORDER BY turn",
+        conv_id,
+    )
+    return [dict(r) for r in rows]

--- a/rhif-clipon/hub/hub.py
+++ b/rhif-clipon/hub/hub.py
@@ -17,7 +17,7 @@ from dotenv import load_dotenv
 from flask import Flask, jsonify, request, render_template
 from flask_cors import CORS
 
-from db import execute, insert_rsp, search_rsps
+from db import execute, insert_rsp, search_rsps, fetch_conversation
 from ollama_helpers import summarise_and_keywords
 from code_utils import extract_markdown_blocks, save_blocks
 
@@ -102,6 +102,16 @@ def search_route():
     if request.headers.get('Accept') == 'application/json':
         return jsonify(rows)
     return render_template('search.html', rows=rows)
+
+
+@app.route('/conversation', methods=['GET'])
+def conversation_route():
+    """Return all packets for a conversation."""
+    conv_id = request.args.get('conv_id')
+    if not conv_id:
+        raise BadRequest('conv_id required')
+    rows = fetch_conversation(conv_id)
+    return jsonify(rows)
 
 
 @app.route('/savecode', methods=['POST'])


### PR DESCRIPTION
## Summary
- switch panel layout to side-by-side results and preview
- keep navigation buttons static and add drag handle
- allow resizing results list horizontally
- support fetching full conversations via new `/conversation` endpoint

## Testing
- `pytest -q rhif-clipon/tests`

------
https://chatgpt.com/codex/tasks/task_e_68566804db148322b40e5acb5aa0d076