### PR TITLE
Fix preview errors

### DIFF
--- a/rhif-clipon/extension/background.js
+++ b/rhif-clipon/extension/background.js
@@ -3,6 +3,16 @@ chrome.runtime.onInstalled.addListener(() => {
 });
 
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
-  fetch(msg.url, msg.options).then(r => r.json()).then(sendResponse).catch(err => sendResponse({ error: err.toString() }));
+  fetch(msg.url, msg.options)
+    .then(async (r) => {
+      const ct = r.headers.get('Content-Type') || '';
+      if (!ct.includes('application/json')) {
+        const text = await r.text();
+        throw new Error(`Non-JSON response: ${text.slice(0, 200)}`);
+      }
+      return r.json();
+    })
+    .then(sendResponse)
+    .catch((err) => sendResponse({ error: err.toString() }));
   return true;
 });

--- a/rhif-clipon/extension/panel.js
+++ b/rhif-clipon/extension/panel.js
@@ -70,9 +70,13 @@ export function initPanel() {
     if (idx < 0 || idx >= rows.length) return;
     const row = rows[idx];
     current = idx;
-    await ensureConversation(row.conv_id);
-    const i = convRows.findIndex(r => r.id === row.id);
-    renderEntry(i === -1 ? 0 : i);
+    try {
+      await ensureConversation(row.conv_id);
+      const i = convRows.findIndex(r => r.id === row.id);
+      renderEntry(i === -1 ? 0 : i);
+    } catch (err) {
+      console.error('Preview failed:', err);
+    }
   }
 
   function updateNav() {
@@ -120,7 +124,12 @@ export function initPanel() {
     if (start) params.append('start', start);
     if (end) params.append('end', end);
     if (slow) params.append('slow', '1');
-    rows = await hubFetch(`/search?${params.toString()}`, { headers: { Accept: 'application/json' } });
+    try {
+      rows = await hubFetch(`/search?${params.toString()}`, { headers: { Accept: 'application/json' } });
+    } catch (err) {
+      console.error('Search failed:', err);
+      return;
+    }
     results.innerHTML = '';
     preview.classList.add('rhif-hidden');
     controls.classList.add('rhif-hidden');


### PR DESCRIPTION
## Summary
- handle non-JSON responses in background.js to avoid unhandled promise rejections
- wrap search/preview calls in try/catch and log errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68566ae8d42483229fedba9357e2d48d