### PR TITLE
Fix conversation preview 404

### DIFF
--- a/rhif-clipon/hub/hub.py
+++ b/rhif-clipon/hub/hub.py
@@ -25,6 +25,7 @@ from code_utils import extract_markdown_blocks, save_blocks
 load_dotenv()
 
 app = Flask(__name__, template_folder='templates')
+app.url_map.strict_slashes = False  # allow optional trailing slashes
 CORS(app, origins=['chrome-extension://*'])
 
 app.config.update(


### PR DESCRIPTION
## Summary
- allow optional trailing slashes for RHIF hub routes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68566c634cd883229466d4edd0809d0d