### PR TITLE
Fix panel toggle losing flex layout

### DIFF
--- a/rhif-clipon/extension/content.js
+++ b/rhif-clipon/extension/content.js
@@ -35,7 +35,7 @@ window.rhifContent = { getLatestChatTurns, insertAtCursor };
   document.body.appendChild(btn);
   makeDraggable(btn, { grid: 20, handle: btn, storageKey: 'rhif-btn' });
   btn.addEventListener('click', () => {
-    panel.style.display = panel.style.display === 'none' || !panel.style.display ? 'block' : 'none';
+    panel.classList.toggle('rhif-hidden');
   });
 
   document.addEventListener('keydown', e => {


### PR DESCRIPTION
## Summary
- ensure the panel keeps its flex layout when toggled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685672aeda548322a294be85f811aec1