### PR TITLE
Fix search header in winapp & add exit shortcut

### DIFF
--- a/winapp/README.md
+++ b/winapp/README.md
@@ -17,4 +17,4 @@ This directory contains a simple standalone desktop application that mirrors the
    python app.py
    ```
 
-The app opens a small floating "R" button. Clicking it toggles the main panel where you can search, preview and copy responses just like the extension.
+The app opens a small floating "R" button. Clicking it toggles the main panel where you can search, preview and copy responses just like the extension. Right-clicking the button exits the app.

--- a/winapp/app.py
+++ b/winapp/app.py
@@ -52,6 +52,7 @@ class RhifApp:
         self.toggle_canvas.bind("<ButtonPress-1>", self.start_drag)
         self.toggle_canvas.bind("<B1-Motion>", self.do_drag)
         self.toggle_canvas.bind("<ButtonRelease-1>", self.end_drag)
+        self.toggle_canvas.bind("<Button-3>", lambda e: self.master.destroy())
 
     def toggle_panel(self):
         if self.panel and self.panel.winfo_viewable():
@@ -167,7 +168,11 @@ class RhifApp:
         if self.slow_var.get():
             params['slow'] = '1'
         try:
-            r = requests.get(f'{HUB_BASE}/search', params=params)
+            r = requests.get(
+                f'{HUB_BASE}/search',
+                params=params,
+                headers={'Accept': 'application/json'}
+            )
             r.raise_for_status()
             self.rows = r.json()
         except Exception as exc:


### PR DESCRIPTION
## Summary
- ensure `/search` requests ask for JSON
- allow right click on the floating **R** icon to exit
- document the new shortcut

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856846127048322b38c9a880e0f9cb9