### PR TITLE
Add dimension lookup schema and migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,14 @@ searches using the `utils.js` helper to call the hub.
 3. Load `extension/` as an unpacked extension in Chrome/Edge.
 4. Import previous conversations using `tools/ingest_export.py` if desired.
 
+### Database migration
+
+After pulling version 2 run the migration script once to upgrade existing
+archives:
+
+```bash
+npm run migrate  # or: python rhif-clipon/tools/migrate_v2.py ./rhif.sqlite
+```
+
+This adds lookup tables for repeated values and rebuilds the FTS indices.
+

--- a/db/init.sql
+++ b/db/init.sql
@@ -1,0 +1,40 @@
+-- Schema for RHIF v2
+
+-- 1-A Lookup table for repeated axis values
+CREATE TABLE IF NOT EXISTS dim_value (
+  id        INTEGER PRIMARY KEY,
+  dimension TEXT NOT NULL,
+  value     TEXT NOT NULL,
+  UNIQUE(dimension,value)
+);
+
+-- 1-B rsp table additions
+ALTER TABLE rsp
+  ADD COLUMN domain_id INT;
+ALTER TABLE rsp
+  ADD COLUMN topic_id INT;
+ALTER TABLE rsp
+  ADD COLUMN convtype_id INT;
+ALTER TABLE rsp
+  ADD COLUMN emotion_id INT;
+
+-- 1-D Re-create FTS tables without keywords and using trigram tokenizer
+DROP TABLE IF EXISTS rsp_fts;
+CREATE VIRTUAL TABLE rsp_fts
+  USING fts5(
+    text,
+    summary,
+    tokenize = 'trigram',
+    content = 'rsp',
+    content_rowid = 'id'
+  );
+
+DROP TABLE IF EXISTS keyword_set_fts;
+CREATE VIRTUAL TABLE keyword_set_fts
+  USING fts5(keywords_json, tokenize='trigram');
+
+-- Covering indices for dimensions
+CREATE INDEX IF NOT EXISTS rsp_domain_idx    ON rsp(domain_id);
+CREATE INDEX IF NOT EXISTS rsp_topic_idx     ON rsp(topic_id);
+CREATE INDEX IF NOT EXISTS rsp_convtype_idx  ON rsp(convtype_id);
+CREATE INDEX IF NOT EXISTS rsp_emotion_idx   ON rsp(emotion_id);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "rhif",
+  "version": "1.0.0",
+  "scripts": {
+    "migrate": "python rhif-clipon/tools/migrate_v2.py ./rhif.sqlite"
+  }
+}

--- a/rhif-clipon/hub/ollama_helpers.py
+++ b/rhif-clipon/hub/ollama_helpers.py
@@ -128,12 +128,13 @@ def _summarise_once(
     else:
         keywords = [k.lower() for k in keywords if isinstance(k, str)]
 
+    novelty_val = float(data.get('novelty', 0))
     meta = {
         'domain': data.get('domain', '').strip().lower(),
         'topic': data.get('topic', '').strip().lower(),
         'conversation_type': data.get('conversation_type', '').strip().lower(),
         'emotion': data.get('emotion', '').strip().lower(),
-        'novelty': float(data.get('novelty', 0))
+        'novelty': round(novelty_val, 2)
     }
 
     return summary, keywords, meta

--- a/rhif-clipon/tests/test_db.py
+++ b/rhif-clipon/tests/test_db.py
@@ -1,7 +1,7 @@
 import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'hub'))
-from db import execute, insert_rsp, search_rsps
+from db import execute, insert_rsp, search_rsps, ensure_schema
 from rhif_utils import canonical_json
 from flask import Flask
 
@@ -11,41 +11,7 @@ app.config['DB_PATH'] = ':memory:'
 
 
 with app.app_context():
-    execute("""CREATE TABLE rsp (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        hash TEXT,
-        conv_id TEXT,
-        turn INTEGER,
-        role TEXT,
-        date TEXT,
-        text TEXT,
-        summary TEXT,
-        keywords TEXT,
-        tags TEXT,
-        tokens INTEGER,
-        meta TEXT,
-        children TEXT,
-        domain TEXT,
-        topic TEXT,
-        conversation_type TEXT,
-        emotion TEXT,
-        novelty INTEGER
-    )""")
-    execute("CREATE VIRTUAL TABLE rsp_fts USING fts5(text, summary, keywords, content='rsp', content_rowid='id')")
-    execute("""CREATE TABLE rsp_index(
-        hash TEXT,
-        dimension TEXT,
-        value TEXT,
-        dimension_hash TEXT,
-        context_path TEXT,
-        UNIQUE(hash, dimension, value)
-    )""")
-    execute("CREATE INDEX rsp_domain_idx ON rsp(domain)")
-    execute("CREATE INDEX rsp_topic_idx ON rsp(topic)")
-    execute("CREATE INDEX idx_keywords_json ON rsp(json_extract(keywords, '$'))")
-    execute("CREATE TABLE keyword_set (id INTEGER PRIMARY KEY AUTOINCREMENT, kw_hash TEXT UNIQUE, keywords_json TEXT)")
-    execute("CREATE VIRTUAL TABLE keyword_set_fts USING fts5(keywords_json)")
-    execute("CREATE TABLE rsp_keyword_xref(rsp_id INT, keyword_set_id INT, PRIMARY KEY(rsp_id, keyword_set_id))")
+    ensure_schema()
 
 def test_insert_and_search():
     with app.app_context():
@@ -60,12 +26,12 @@ def test_keyword_canonicalisation_and_search():
     from rhif_utils import canonical_keyword_list
     with app.app_context():
         rowid = insert_rsp({'conv_id':'2','turn':1,'role':'user','date':'2024-01-01',
-                             'text':'foo','summary':'bar','keywords':'["A","b","a"]',
+                             'text':'foo','summary':'bar','keywords':'["alpha","beta","alpha"]',
                              'tags':'[]','tokens':1,'domain':'test','topic':'unit'})
         kw_row = execute("SELECT keyword_set_id FROM rsp_keyword_xref WHERE rsp_id=?", rowid)[0]
         kw_json = execute("SELECT keywords_json FROM keyword_set WHERE id=?", kw_row['keyword_set_id'])[0]['keywords_json']
-        assert kw_json == canonical_json(canonical_keyword_list(['A','b','a']))
-        res = search_rsps('foo', [], 10, keywords='a')
+        assert kw_json == canonical_json(canonical_keyword_list(['alpha','beta','alpha']))
+        res = search_rsps('foo', [], 10, keywords='alpha')
         assert any(r['id'] == rowid for r in res)
 
 

--- a/rhif-clipon/tools/migrate_v2.py
+++ b/rhif-clipon/tools/migrate_v2.py
@@ -1,0 +1,96 @@
+"""One-off migration to RHIF schema v2.
+
+Steps:
+ 1. Apply schema changes (dim_value table, FK cols, new FTS tables).
+ 2. Populate FK columns from existing text values.
+ 3. Rebuild FTS tables and vacuum the database.
+
+Run once:
+    python migrate_v2.py ./rhif.sqlite
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+from tqdm import tqdm
+
+
+def _dim_id(cur: sqlite3.Cursor, dim: str, val: str | None) -> int | None:
+    if not val:
+        return None
+    cur.execute(
+        "INSERT OR IGNORE INTO dim_value(dimension,value) VALUES (?,?)",
+        (dim, val),
+    )
+    return cur.execute(
+        "SELECT id FROM dim_value WHERE dimension=? AND value=?",
+        (dim, val),
+    ).fetchone()[0]
+
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS dim_value (
+  id        INTEGER PRIMARY KEY,
+  dimension TEXT NOT NULL,
+  value     TEXT NOT NULL,
+  UNIQUE(dimension,value)
+);
+ALTER TABLE rsp ADD COLUMN domain_id INT;
+ALTER TABLE rsp ADD COLUMN topic_id INT;
+ALTER TABLE rsp ADD COLUMN convtype_id INT;
+ALTER TABLE rsp ADD COLUMN emotion_id INT;
+DROP TABLE IF EXISTS rsp_fts;
+CREATE VIRTUAL TABLE rsp_fts USING fts5(
+  text,
+  summary,
+  tokenize='trigram',
+  content='rsp',
+  content_rowid='id'
+);
+DROP TABLE IF EXISTS keyword_set_fts;
+CREATE VIRTUAL TABLE keyword_set_fts USING fts5(keywords_json, tokenize='trigram');
+CREATE INDEX IF NOT EXISTS rsp_domain_idx ON rsp(domain_id);
+CREATE INDEX IF NOT EXISTS rsp_topic_idx ON rsp(topic_id);
+CREATE INDEX IF NOT EXISTS rsp_convtype_idx ON rsp(convtype_id);
+CREATE INDEX IF NOT EXISTS rsp_emotion_idx ON rsp(emotion_id);
+"""
+
+
+def migrate(db_path: Path) -> None:
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.executescript(SCHEMA_SQL)
+
+    rows = cur.execute(
+        "SELECT id, domain, topic, conversation_type, emotion FROM rsp"
+    ).fetchall()
+    for r in tqdm(rows, desc="rsp"):
+        d = _dim_id(cur, "domain", r[1])
+        t = _dim_id(cur, "topic", r[2])
+        c = _dim_id(cur, "conversation_type", r[3])
+        e = _dim_id(cur, "emotion", r[4])
+        cur.execute(
+            "UPDATE rsp SET domain_id=?, topic_id=?, convtype_id=?, emotion_id=?,"
+            " domain=NULL, topic=NULL, conversation_type=NULL, emotion=NULL WHERE id=?",
+            (d, t, c, e, r[0]),
+        )
+
+    cur.execute("DELETE FROM rsp_fts")
+    for rid, text, summary in tqdm(
+        cur.execute("SELECT id, text, summary FROM rsp"), desc="fts rebuild"
+    ):
+        cur.execute(
+            "INSERT INTO rsp_fts(rowid, text, summary) VALUES (?,?,?)",
+            (rid, text, summary),
+        )
+
+    conn.commit()
+    cur.execute("VACUUM")
+    conn.commit()
+    conn.close()
+
+
+if __name__ == "__main__":
+    db_file = Path(sys.argv[1] if len(sys.argv) > 1 else "./rhif.sqlite")
+    migrate(db_file)


### PR DESCRIPTION
## Summary
- create schema SQL and migration helper for v2
- track dimension values and IDs in `db.py`
- rebuild FTS with trigram tokenizer
- round novelty in Ollama helpers
- add npm `migrate` alias and update README
- adjust unit tests for new schema

## Testing
- `pip install flask flask-cors ollama ijson python-dotenv tqdm regex pandas`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856e6f0c0388322ae16ae495f852250