### PR TITLE
Fix migrate_v2 on old DB

### DIFF
--- a/rhif-clipon/tools/migrate_v2.py
+++ b/rhif-clipon/tools/migrate_v2.py
@@ -76,7 +76,7 @@ def migrate(db_path: Path) -> None:
             (d, t, c, e, r[0]),
         )
 
-    cur.execute("DELETE FROM rsp_fts")
+    # rebuild FTS table from scratch
     for rid, text, summary in tqdm(
         cur.execute("SELECT id, text, summary FROM rsp"), desc="fts rebuild"
     ):


### PR DESCRIPTION
## Summary
- remove stale `DELETE FROM rsp_fts` statement from migration script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856ec2193ec832280f3349c4c20f48e