### PR TITLE
Fix module imports and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ searches using the `utils.js` helper to call the hub.
 ## Usage
 
 1. Install dependencies as described in `rhif-clipon/README.md`.
-2. Run the hub with `python hub/hub.py`.
+2. Run the hub with `python -m hub.hub`.
 3. Load `extension/` as an unpacked extension in Chrome/Edge.
 4. Import previous conversations using `tools/ingest_export.py` if desired.
 

--- a/rhif-clipon/README.md
+++ b/rhif-clipon/README.md
@@ -23,7 +23,7 @@ Create a `.env` to override defaults if needed.
 ## Running
 
 ```bash
-python hub/hub.py
+python -m hub.hub
 ```
 
 Load `extension/` as an unpacked extension in Chrome/Edge.

--- a/rhif-clipon/hub/db.py
+++ b/rhif-clipon/hub/db.py
@@ -19,7 +19,12 @@ import hashlib
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
-from rhif_utils import canonical_json, rsp_hash, flatten_meta, canonical_keyword_list
+from .rhif_utils import (
+    canonical_json,
+    rsp_hash,
+    flatten_meta,
+    canonical_keyword_list,
+)
 
 from flask import current_app
 

--- a/rhif-clipon/hub/hub.py
+++ b/rhif-clipon/hub/hub.py
@@ -18,9 +18,9 @@ from flask import Flask, jsonify, request, render_template
 from flask_cors import CORS
 from werkzeug.exceptions import BadRequest
 
-from db import execute, insert_rsp, search_rsps, fetch_conversation
-from ollama_helpers import summarise_and_keywords
-from code_utils import extract_markdown_blocks, save_blocks
+from .db import execute, insert_rsp, search_rsps, fetch_conversation
+from .ollama_helpers import summarise_and_keywords
+from .code_utils import extract_markdown_blocks, save_blocks
 
 
 load_dotenv()
@@ -134,7 +134,7 @@ def health_route():
 
 
 if __name__ == '__main__':
-    from db import ensure_schema
+    from .db import ensure_schema
     with app.app_context():
         ensure_schema()
     port = app.config['HUB_PORT']

--- a/rhif-clipon/tests/test_code_utils.py
+++ b/rhif-clipon/tests/test_code_utils.py
@@ -1,7 +1,7 @@
 import sys
 from pathlib import Path
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'hub'))
-from code_utils import extract_markdown_blocks
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from hub.code_utils import extract_markdown_blocks
 
 
 def test_extract_blocks():

--- a/rhif-clipon/tests/test_db.py
+++ b/rhif-clipon/tests/test_db.py
@@ -1,8 +1,8 @@
 import sys
 from pathlib import Path
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'hub'))
-from db import execute, insert_rsp, search_rsps, ensure_schema
-from rhif_utils import canonical_json
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from hub.db import execute, insert_rsp, search_rsps, ensure_schema
+from hub.rhif_utils import canonical_json
 from flask import Flask
 
 

--- a/rhif-clipon/tests/test_ollama_helpers.py
+++ b/rhif-clipon/tests/test_ollama_helpers.py
@@ -1,8 +1,8 @@
 import sys
 from pathlib import Path
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'hub'))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from ollama_helpers import _extract_json
+from hub.ollama_helpers import _extract_json
 
 
 def test_extract_json_direct():


### PR DESCRIPTION
## Summary
- switch to package-relative imports in hub modules
- update tests to import from the `hub` package
- document using `python -m hub.hub` to run the server

## Testing
- `pip install -r hub/requirements.txt` *(fails: no output)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6856faaef8088322b11ba870b46475a1